### PR TITLE
Rename QClipBoard to QClipboard

### DIFF
--- a/src/plugins/projectexplorer/foldernavigationwidget.cpp
+++ b/src/plugins/projectexplorer/foldernavigationwidget.cpp
@@ -64,7 +64,7 @@
 #include <QMenu>
 #include <QFileDialog>
 #include <QContextMenuEvent>
-#include <QClipBoard>
+#include <QClipboard>
 
 // JULIA STUDIO -------
 #include "ievaluator.h"


### PR DESCRIPTION
QT 4.8 changed the names

Literally changing this one include fixes the build on arch against QT 4.8.  I'm sure there's a way to build against 4.7 and 4.8 but a quick google didn't discover it.
