### PR TITLE
path to juliet.jl in Console.jl corrected to work on case-sensitive fs

### DIFF
--- a/share/qtcreator/Console/Console.jl
+++ b/share/qtcreator/Console/Console.jl
@@ -1,5 +1,5 @@
 
-require("../Juliet/src/Juliet.jl")
+require("../juliet/src/Juliet.jl")
 include("ConsoleLogic.jl")
 
 import Juliet


### PR DESCRIPTION
Hey there,

I've just cloned the repository, compiled (under Kubuntu 12.04 64bit) and started JuliaStudio. I got an error that share/qtcreator/Juliet/src/Juliet.jl cannot be found. Turned out the path to the file used an uppercase character share/qtcreator/Juliet/src/Juliet.jl while it should have been /share/qtcreator/juliet/src/Juliet.jl

Fixed that and the wonderful JuliaStudio worked as expected.

best,
Georgi
