### PR TITLE
fixes 64-bit linux build issue:  incomplete type ‘QApplication’ ...

### DIFF
--- a/src/plugins/coreplugin/fancytabwidget.cpp
+++ b/src/plugins/coreplugin/fancytabwidget.cpp
@@ -33,7 +33,7 @@
 #include <utils/styledbar.h>
 
 #include <QDebug>
-
+#include <QApplication>
 #include <QColorDialog>
 #include <QHBoxLayout>
 #include <QVBoxLayout>


### PR DESCRIPTION
Last night while compiling Julia Studio on a fresh install of 64-bit Ubuntu 12.04 LTS, I got the below error.  The resolution was to add 

``` c++
#include <QApplication> 
```

to fancytabwidget.cpp.  This is apparently something that shouldn't happen, and it is not clear if I should be

```
g++ -c -m64 -pipe -O2 -fvisibility=hidden -fvisibility-inlines-hidden -Wall -W -D_REENTRANT -fPIC -DCORE_LIBRARY -DIDE_LIBRARY_BASENAME=\"lib\" -DQT_NO_CAST_TO_ASCII -DQT_USE_FAST_OPERATOR_PLUS -DQT_USE_FAST_CONCATENATION -DQT_NO_DEBUG -DQT_PLUGIN -DQT_SCRIPT_LIB -DQT_SQL_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -I/usr/share/qt4/mkspecs/linux-g++-64 -I. -I/usr/include/qt4/QtCore -I/usr/include/qt4/QtNetwork -I/usr/include/qt4/QtGui -I/usr/include/qt4/QtSql -I/usr/include/qt4/QtScript -I/usr/include/qt4 -I/usr/include/qt4/QtHelp -I../../../src -I../../libs -I/home/stu/julia/julia-studio/tools -I../../plugins -I../../shared/scriptwrapper -Idialogs -Iactionmanager -Ieditormanager -Iprogressmanager -Iscriptmanager -I.moc/release-shared -I.uic -o .obj/release-shared/fancytabwidget.o fancytabwidget.cpp
fancytabwidget.cpp:89:11: warning: extra tokens at end of #endif directive [enabled by default]
fancytabwidget.cpp: In destructor ‘virtual Core::Internal::FancyTabBar::~FancyTabBar()’:
fancytabwidget.cpp:102:16: error: incomplete type ‘QApplication’ used in nested name specifier
make[3]: *** [.obj/release-shared/fancytabwidget.o] Error 1
make[3]: Leaving directory `/home/stu/julia/julia-studio/src/plugins/coreplugin'
make[2]: *** [sub-coreplugin-make_default] Error 2
make[2]: Leaving directory `/home/stu/julia/julia-studio/src/plugins'
make[1]: *** [sub-plugins-make_default-ordered] Error 2
make[1]: Leaving directory `/home/stu/julia/julia-studio/src'
make: *** [sub-src-make_default-ordered] Error 2
```
