### PR TITLE
Fixes logo URL in README.md (1-char patch)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <a name="logo"/>
 <div align="center">
 <a href="http://forio.com/products/julia-studio/" target="_blank">
-<img src="http://github.com/forio/julia-studio/blob/master/src/plugins/juliaeditor/images/js-by-forio.png?raw=true" alt="Julia Logo" width="525" height="128"></img>
+<img src="https://github.com/forio/julia-studio/blob/master/src/plugins/juliaeditor/images/js-by-forio.png?raw=true" alt="Julia Logo" width="525" height="128"></img>
 </a>
 </div>
 


### PR DESCRIPTION
Chrome states:
    "Refused to load the image
    'http://github.com/.../js-by-forio.png?raw=true' because it
    violates the following Content Security Policy directive: ..."

This changes the URL to HTTPS. Protocol-relative URLs don't seem to work
with markdown.
