### PR TITLE
Finalise Linux installation

### DIFF
--- a/linux-build.md
+++ b/linux-build.md
@@ -90,7 +90,7 @@ cd /usr/local/bin
 ln -s ~/julia-studio/julia-studio.sh julia-studio
 ```
 
-#Presto!  You can start Julia Studio now with `julia-studio`.
+#Presto!  You can start Julia Studio now.
 
 This document is a work in progress and subject to change as we develope Julia Studio.  Please create an issue if you run into a problem.  We'll get back to you pronto.
 

--- a/linux-build.md
+++ b/linux-build.md
@@ -79,9 +79,18 @@ Julia Studio looks for a link to the Julia binary in its bin directory, along si
 ```bash
 cd bin/
 ln -s /usr/bin/julia-basic julia-basic
+cd ~/julia-studio
+ln -s /usr/bin/julia-basic julia-basic
 ```
 
-#Presto!  You can start Julia Studio now.
+Lastly make the command accessible from a shell anywhere with another symbolic link:
+
+```bash
+cd /usr/local/bin
+ln -s ~/julia-studio/julia-studio.sh julia-studio
+```
+
+#Presto!  You can start Julia Studio now with `julia-studio`.
 
 This document is a work in progress and subject to change as we develope Julia Studio.  Please create an issue if you run into a problem.  We'll get back to you pronto.
 


### PR DESCRIPTION
After the final `make` command as per linuxbuild.md instructs ([sort of anyway](https://github.com/forio/julia-studio/pull/236)), there is no Julia Studio program nor a julia-studio command to start the program.

I'm not sure if adding `qtbase` to the `PATH` variable is supposed to enable this, but it doesn't for me. Removing it just removes the `junit` command which isn't something needed anyway but I've left it there.

The code in this pull request makes a shell command `julia-studio` which accesses julia-studio/bin/julia-studio.sh, I'm not sure how you'd add the program to the Linux applications menu
