### PR TITLE
Issue #247 Update ConsoleLogic.jl to use length(range) instead of range.len

### DIFF
--- a/share/julia-studio/Console/ConsoleLogic.jl
+++ b/share/julia-studio/Console/ConsoleLogic.jl
@@ -207,7 +207,7 @@ function on_complete_msg( console::ConsoleLogicSystem, cid, prefix )
   event_system = get_system(Event.EventSystem)
 
   result, range = completions( prefix, length( prefix ) )
-  Event.new_event( event_system, "networkOut", cid, "output-complete", [ [ string( range.start ), string( range.len ) ], result ] )
+  Event.new_event( event_system, "networkOut", cid, "output-complete", [ [ string( range.start ), string( length(range) ) ], result ] )
 end
 
 function on_watch_msg( console::ConsoleLogicSystem, cid, command )


### PR DESCRIPTION
Converted range.len to length(range)  range has no len field, only start and stop so length(range) is appropriate to get the length
